### PR TITLE
Dialogs styling for preference fragments

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -17,6 +17,7 @@
         <entry key="app/src/main/res/menu/bottom_nav_destinations.xml" value="0.1" />
         <entry key="app/src/main/res/menu/dropdown_menu_sample.xml" value="0.35104166666666664" />
         <entry key="app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.278" />
+        <entry key="uihouse/src/main/res/drawable/alert_dialog_background.xml" value="0.23" />
         <entry key="uihouse/src/main/res/drawable/bottom_sheet_background.xml" value="0.278" />
         <entry key="uihouse/src/main/res/drawable/bottom_sheet_grip.xml" value="0.278" />
         <entry key="uihouse/src/main/res/drawable/ic_baseline_photo_camera_24.xml" value="0.2465" />

--- a/lint/src/main/java/org/mifos/mobile/ui/lint/NonLibraryStyleDetector.kt
+++ b/lint/src/main/java/org/mifos/mobile/ui/lint/NonLibraryStyleDetector.kt
@@ -35,7 +35,8 @@ class NonLibraryStyleDetector : LayoutDetector() {
     override fun visitAttribute(context: XmlContext, attribute: Attr) {
         val allowedPrefix = listOf(
             "@style/Mifos.DesignSystem.TextStyle.",
-            "@style/Mifos.DesignSystem.Components."
+            "@style/Mifos.DesignSystem.Components.",
+            "?"
         )
         attribute.nodeValue.let { attrValue ->
             if (attrValue != SdkConstants.VALUE_WRAP_CONTENT

--- a/uihouse/src/main/res/drawable/alert_dialog_background.xml
+++ b/uihouse/src/main/res/drawable/alert_dialog_background.xml
@@ -1,0 +1,25 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="?attr/colorSurface"/>
+            <corners
+                android:bottomLeftRadius="28dp"
+                android:bottomRightRadius="28dp"
+                android:topLeftRadius="28dp"
+                android:topRightRadius="28dp"/>
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@color/m3_popupmenu_overlay_color"/>
+            <corners
+                android:bottomLeftRadius="28dp"
+                android:bottomRightRadius="28dp"
+                android:topLeftRadius="28dp"
+                android:topRightRadius="28dp"/>
+            <padding
+                android:bottom="8dp"
+                android:top="8dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/uihouse/src/main/res/values-night/theme.xml
+++ b/uihouse/src/main/res/values-night/theme.xml
@@ -30,6 +30,7 @@
 
         <item name="android:textViewStyle">@style/Mifos.DesignSystem.TextStyle.Body</item>
         <item name="profileImageViewStyle">@style/Mifos.DesignSystem.Components.ProfileImage</item>
+        <item name="alertDialogTheme">@style/dialog_theme</item>
 
         <item name="colorSuccess">#67de7a</item>
         <item name="colorOnSuccess">#003912</item>

--- a/uihouse/src/main/res/values/styles.xml
+++ b/uihouse/src/main/res/values/styles.xml
@@ -36,6 +36,9 @@
         <item name="buttonBarPositiveButtonStyle">@style/Mifos.DesignSystem.Components.Button.Red</item>
         <item name="buttonBarNeutralButtonStyle">@style/Mifos.DesignSystem.Components.Button.Neutral</item>
     </style>
+    <style name="dialog_theme" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="android:windowBackground">@drawable/alert_dialog_background</item>
+    </style>
 
     <!--Style for the custom ProcessView lines-->
     <style name="Mifos.DesignSystem.Components.ProcessViewLine" parent="android:Widget">

--- a/uihouse/src/main/res/values/theme.xml
+++ b/uihouse/src/main/res/values/theme.xml
@@ -30,6 +30,7 @@
 
         <item name="android:textViewStyle">@style/Mifos.DesignSystem.TextStyle.Body</item>
         <item name="profileImageViewStyle">@style/Mifos.DesignSystem.Components.ProfileImage</item>
+        <item name="alertDialogTheme">@style/dialog_theme</item>
 
         <item name="colorSuccess">#006e29</item>
         <item name="colorOnSuccess">#ffffff</item>


### PR DESCRIPTION
Preference Fragment dialogs' use platform dialog builder, so styles don't get apply correctly. So this is fix for that. 